### PR TITLE
Change the npm registry scope to provenance-io (from provenanceio-bot).

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Set tag version
         run: |
-         VERSION=${GITHUB_REF##*/}
+          VERSION=${GITHUB_REF##*/}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           PRE_RELEASE=false
           if [[ "$VERSION" =~ -rc ]]; then
@@ -52,10 +52,10 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.TAGS }}
-      - name: Release Artifacts
-        uses: ncipollo/release-action@v1
+      - name: Create release
+        uses: actions/create-release@v1
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
           prerelease: ${{ env.PRE_RELEASE }}
-          bodyFile: "RELEASE_CHANGELOG.md"
+          body_path: "RELEASE_CHANGELOG.md"

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 scripts-prepend-node-path=true
 //npm.pkg.github.com/:_authToken=${NPM_TOKEN}
-@provenance-io:registry=https://npm.pkg.github.com
+@provenanceio:registry=https://npm.pkg.github.com
 always-auth=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 scripts-prepend-node-path=true
 //npm.pkg.github.com/:_authToken=${NPM_TOKEN}
-@provenanceio-bot:registry=https://npm.pkg.github.com
+@provenance-io:registry=https://npm.pkg.github.com
 always-auth=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,15 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ---
 
-## [0.1.0-r1](https://github.com/provenance-io/npm-publishing/releases/tag/0.1.0-rc1) - 2023-03-30
+## [0.1.0-rc2](https://github.com/provenance-io/npm-publishing/releases/tag/0.1.0-rc2) - 2023-04-17
+
+### Bug Fixes
+
+* [PR 39](https://github.com/provenance-io/npm-publish/pull/39) [PR 40](https://github.com/provenance-io/npm-publish/pull/40) Fix npm authentication.
+
+---
+
+## [0.1.0-rc1](https://github.com/provenance-io/npm-publishing/releases/tag/0.1.0-rc1) - 2023-03-30
 
 ### Improvements
 

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -1,0 +1,6 @@
+## [0.1.0-rc2](https://github.com/provenance-io/npm-publishing/releases/tag/0.1.0-rc2) - 2023-04-17
+
+### Bug Fixes
+
+* [PR 39](https://github.com/provenance-io/npm-publish/pull/39) [PR 40](https://github.com/provenance-io/npm-publish/pull/40) Fix npm authentication.
+


### PR DESCRIPTION
## Description

Change the npm registry scope (in .npmrc) to `provenance-io` (from `provenanceio-bot`).

From the looks of githubs `setup-node` action, that's what it would end up as unless otherwise specified.

This also updates the changelog and release changelog in prep for a new rc.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance-abci-listener/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
